### PR TITLE
small typo in _tags.py function docstring

### DIFF
--- a/google/colab/output/_tags.py
+++ b/google/colab/output/_tags.py
@@ -134,7 +134,7 @@ def clear(wait=False, output_tags=()):
   For example:
     from google.colab import output
     with output.use_tag('conversation'):
-      with output.use_tag('introduction')
+      with output.use_tag('introduction'):
          print 'Hello'
       print 'Bye'
 


### PR DESCRIPTION
just updating the code comment so that people can copy-and-paste the example safely, without getting a syntax error from the missing colon on the inner `with` clause:
```
    from google.colab import output
    with output.use_tag('conversation'):
      with output.use_tag('introduction'):
         print 'Hello'
      print 'Bye'
```