### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ DEPENDENCIES = (
     'six~=1.11.0',
     'portpicker~=1.2.0',
     'requests~=2.18.0',
-    'tornado~=4.5.0',
+    'tornado~=5.0.0',
 )
 
 setup(


### PR DESCRIPTION
- Google colab comes with many packages already installed, including `distributed==1.26.0`.
- However, `distributed` version 1.26.0 depends on `tornado` version `>5`. But colab depends on version `>=4.5.0`. This creates a conflict in that distributed depends on an new pypi package, and colab depends on an older version of that package. The older version is installed, and this creates an issue if you use colab and try to upgrade a package that depends on `distributed`, such as `featuretools`