### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,16 @@ from setuptools import setup
 DEPENDENCIES = (
     # Note: these dependency versions should be kept in-sync with the versions
     # specified in the docker container requirements files.
-    'google-auth~=1.4.0',
-    'ipykernel~=4.6.0',
-    'ipython~=5.5.0',
-    'notebook~=5.2.0',
-    'six~=1.12.0',
-    'pandas~=0.24.0; python_version < "3.0"',
-    'pandas~=0.25.0; python_version >= "3.0"',
-    'portpicker~=1.2.0',
-    'requests~=2.21.0',
-    'tornado~=4.5.0',
+    'google-auth',
+    'ipykernel',
+    'ipython',
+    'notebook',
+    'six',
+    'pandas<=0.24.0; python_version < "3.0"',
+    'pandas>=0.25.0; python_version >= "3.0"',
+    'portpicker',
+    'requests',
+    'tornado',
 )
 
 setup(


### PR DESCRIPTION
the absent package versions may introducing breaking changes, 
but some fixed versions here is pulling in major depcrecated datascience package. 
i did not found out which one with pipdeptree. Can you find which package is pulling in deprecated datascience?
without the fixed versions, it works with datascience==0.10.6