### PR TITLE
Import `traitlets` as top-level module

### DIFF
--- a/google/colab/_reprs.py
+++ b/google/colab/_reprs.py
@@ -6,19 +6,13 @@ import io
 import json
 import types
 import uuid
-import warnings
 from google.colab import _inspector
 # pytype: disable=import-error
 import IPython
 from IPython.core import oinspect
 import numpy as np
 import PIL as pil
-# pylint: disable=g-import-not-at-top
-with warnings.catch_warnings():
-  # Importing via IPython raises a spurious warning, but avoids a version
-  # mismatch internally.
-  warnings.simplefilter('ignore')
-  from IPython.utils import traitlets
+import traitlets
 
 
 _original_string_formatters = {}

--- a/google/colab/data_table.py
+++ b/google/colab/data_table.py
@@ -24,7 +24,6 @@ Example:
 import html as _html
 import json as _json
 import traceback as _traceback
-import warnings as _warnings
 
 from google.colab import _interactive_table_helper
 from google.colab import _quickchart_hint_button
@@ -33,14 +32,7 @@ from google.colab import widgets as _widgets
 import IPython as _IPython
 from IPython import display as _display
 import packaging.version as _version
-
-
-# pylint: disable=g-import-not-at-top
-with _warnings.catch_warnings():
-  # Importing via IPython raises a spurious warning, but avoids a version
-  # mismatch internally.
-  _warnings.simplefilter('ignore')
-  from IPython.utils import traitlets as _traitlets
+import traitlets as _traitlets
 
 # pylint: enable=g-import-not-at-top
 


### PR DESCRIPTION
This change helps fix issues like https://stackoverflow.com/questions/75666380/attributeerror-module-ipython-utils-traitlets-has-no-attribute-unicode

I noticed that the rationale
```
# Importing via IPython raises a spurious warning, but avoids a version
# mismatch internally.
```
dates back 4 years ago, so wondering if it's not an issue no longer?
Thank you.