### PR TITLE
Contribute an org 'no response' workflow template

### DIFF
--- a/.github/workflow-templates/no-response.properties.json
+++ b/.github/workflow-templates/no-response.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "A 'reply-needed' bot (colabtools)",
+    "description": "Automation to close 'reply-needed' labelled issues after 21 days of no response",
+    "iconName": "colab",
+    "categories": [
+        "Colab"
+    ]
+}

--- a/.github/workflow-templates/no_response.yaml
+++ b/.github/workflow-templates/no_response.yaml
@@ -1,0 +1,33 @@
+# A workflow to close issues where the author hasn't responded to a request for
+# more information; see https://github.com/godofredoc/no-response for docs.
+
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Every day at 8:00 am
+    - cron: '0 8 * * *'
+
+# All permissions not specified are set to 'none'.
+permissions:
+  issues: write
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'googlecolab' }}
+    steps:
+      - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
+        with:
+          responseRequiredLabel: "reply-needed"
+          responseRequiredColor: 8a9113
+          closeComment: >
+            Without additional information we're not able to resolve this issue,
+            so it will be closed at this time. You're still free to add more
+            info and respond to any questions above, though. We'll re-open the
+            issue if you do. Thanks for your contribution!
+          daysUntilClose: 21
+          token: ${{ github.token }}


### PR DESCRIPTION
With this workflow, issues labeled `reply-needed` will automatically be closed after 21 days. Users can still reopen the issues. I don't seem like I have full permissions for the googlecolab github repo yet so I had to guess at the correct label color.

This is inspired by similar templates used by Dart and Flutter. https://github.com/dart-lang/.github/pull/33

