### PR TITLE
Fix expected label color in no_response.yaml

### DIFF
--- a/.github/workflows/no_response.yaml
+++ b/.github/workflows/no_response.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
         with:
           responseRequiredLabel: "reply-needed"
-          responseRequiredColor: 8a9113
+          responseRequiredColor: 8b9213
           closeComment: >
             Without additional information we're not able to resolve this issue,
             so it will be closed at this time. You're still free to add more


### PR DESCRIPTION
I'd guessed at the label color using chrome devtools as I didn't have full repo access when I made the commit and guessed wrong.